### PR TITLE
Update acvm to published version & pass down feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 
 [dependencies]
 
-acvm = { git = "https://github.com/noir-lang/noir", rev = "cc5ee63072e09779bebd7e7dd054ae16be307d7f" } 
-arkworks_backend = { git = "https://github.com/noir-lang/arkworks_backend", rev = "ee6d468f5cc635dc2589965b6bf16cd2a839d7d3" }
+acvm = "0.3.1"
+arkworks_backend = { git = "https://github.com/noir-lang/arkworks_backend", rev = "2f3f0db182004d5c01008c741bf519fe6798e24d" }
 
 [features]
-# not specifying a default sometimes gives an error that "extern location for acvm does not exist" on some imports locally, 
+# not specifying a default sometimes gives an error that "extern location for acvm does not exist" on some imports locally,
 # but it still builds when specifying `marlin_arkworks_backend/[field name]` in the Cargo.toml inside the nargo crate
 # uncomment the default line to remove extern location errors, it is most likely a coloring error
-# default = ["bls12_381"] 
+# default = ["bls12_381"]
 bn254 = ["arkworks_backend/bn254"]
 bls12_381 = ["arkworks_backend/bls12_381"]

--- a/src/acvm_interop/proof_system.rs
+++ b/src/acvm_interop/proof_system.rs
@@ -1,12 +1,19 @@
 use std::collections::BTreeMap;
 
-use acvm::{Language, ProofSystemCompiler};
-use acvm::acir::{circuit::Circuit, native_types::Witness};
-use acvm::FieldElement;
+use acvm::acir::{circuit::Circuit, native_types::Witness, BlackBoxFunc};
+use acvm::{FieldElement, Language, ProofSystemCompiler};
 
 use super::Marlin;
 
 impl ProofSystemCompiler for Marlin {
+    fn get_exact_circuit_size(&self, _: Circuit) -> u32 {
+        todo!()
+    }
+
+    fn blackbox_function_supported(&self, _: &BlackBoxFunc) -> bool {
+        false
+    }
+
     fn prove_with_meta(
         &self,
         circuit: Circuit,

--- a/src/acvm_interop/pwg.rs
+++ b/src/acvm_interop/pwg.rs
@@ -1,8 +1,6 @@
-use acvm::{
-    PartialWitnessGenerator,
-};
-use acvm::acir::{self, circuit::gate::GadgetCall, native_types::Witness};
-use acvm::FieldElement;
+use acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
+use acvm::PartialWitnessGenerator;
+use acvm::{FieldElement, OpcodeResolutionError};
 use std::collections::BTreeMap;
 
 mod gadget_call;
@@ -11,11 +9,11 @@ use self::gadget_call::GadgetCaller;
 use super::Marlin;
 
 impl PartialWitnessGenerator for Marlin {
-    fn solve_gadget_call(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>, 
-        gc: &GadgetCall
-    ) -> Result<(), acir::OPCODE> {
-        GadgetCaller::solve_gadget_call(initial_witness, gc)
+    fn solve_blackbox_function_call(
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        gc: &BlackBoxFuncCall,
+    ) -> Result<(), OpcodeResolutionError> {
+        GadgetCaller::solve_blackbox_function_call(initial_witness, gc)
     }
     //XXX: marlin is using r1cs? if so truncate should be done with split&join as there is probably no rangecheck
     // a method should be added to acvm PWG that can be overwritten here for the truncate directive

--- a/src/acvm_interop/pwg/gadget_call.rs
+++ b/src/acvm_interop/pwg/gadget_call.rs
@@ -1,16 +1,18 @@
-use acvm::acir::{circuit::gate::GadgetCall, native_types::Witness, OPCODE};
-use acvm::FieldElement;
+use acvm::acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness};
+use acvm::{FieldElement, OpcodeResolutionError};
 use std::collections::BTreeMap;
 
 pub struct GadgetCaller;
 
 impl GadgetCaller {
-    pub fn solve_gadget_call(
+    pub fn solve_blackbox_function_call(
         _initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gadget_call: &GadgetCall,
-    ) -> Result<(), OPCODE> {
+        gadget_call: &BlackBoxFuncCall,
+    ) -> Result<(), OpcodeResolutionError> {
         // XXX: arkworks currently does not implement any of the ACIR opcodes
         // except for arithmetic
-        Err(gadget_call.name)
+        Err(OpcodeResolutionError::UnsupportedBlackBoxFunc(
+            gadget_call.name,
+        ))
     }
 }


### PR DESCRIPTION
This is a WIP that needs help from @vezenovm because I'm not sure what changes to make for the breaking acvm changes.

This updates to the published acvm version to stay in line with the noir repo and then passes down the appropriate feature flags to the acvm crate.